### PR TITLE
Fix Press crash

### DIFF
--- a/src/main/java/com/injir/create_brass_coated/blocks/press/BrassMechanicalPressTileEntity.java
+++ b/src/main/java/com/injir/create_brass_coated/blocks/press/BrassMechanicalPressTileEntity.java
@@ -135,7 +135,7 @@ public class BrassMechanicalPressTileEntity extends BasinOperatingTileEntity imp
 				ItemEntity created =
 					new ItemEntity(level, itemEntity.getX(), itemEntity.getY(), itemEntity.getZ(), result);
 				created.setDefaultPickUpDelay();
-				created.setDeltaMovement(VecHelper.offsetRandomly(Vec3.ZERO, (RandomSource) Create.RANDOM, .05f));
+				created.setDeltaMovement(VecHelper.offsetRandomly(Vec3.ZERO, level.random, .05f));
 				level.addFreshEntity(created);
 			}
 			item.shrink(1);


### PR DESCRIPTION
Fixed a game crash that occurred when trying to press an item in-world. This would happen because in 1.19 create.VecHelper.offsetRandomly now takes a RandomSource. The original update casts Create.RANDOM to a Random Source, raising a ClassCastException. The new fix comes from the Create mod. (https://github.com/InJir69/create_brass_coated/blob/main/src/main/java/com/injir/create_brass_coated/blocks/press/BrassMechanicalPressTileEntity.java)